### PR TITLE
[トーク画面の作成]

### DIFF
--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../hooks/useAuth';
 import LoadingSpinner from '../ui/LoadingSpinner';
@@ -39,6 +39,18 @@ export default function ChatScreen({}: ChatScreenProps) {
   const [newMessage, setNewMessage] = useState('');
   const [loading, setLoading] = useState(true);
   const [sendingMessage, setSendingMessage] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
+
+  // メッセージエリアを最下部にスクロール
+  const scrollToBottom = () => {
+    if (messagesEndRef.current) {
+      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    } else if (messagesContainerRef.current) {
+      messagesContainerRef.current.scrollTop = messagesContainerRef.current.scrollHeight;
+    }
+  };
 
   useEffect(() => {
     fetchBoards();
@@ -51,27 +63,40 @@ export default function ChatScreen({}: ChatScreenProps) {
   //   }
   // }, [selectedBoard]);
   // 修正後の useEffect
-useEffect(() => {
-  let unsubscribe: (() => void) | undefined;
+  useEffect(() => {
+    let unsubscribe: (() => void) | undefined;
 
-  if (selectedBoard) {
-    fetchMessages(selectedBoard);
-    // 💡 購読関数から返されるクリーンアップ関数を変数に保持
-    unsubscribe = subscribeToMessages(selectedBoard);
-  }
-
-  // 💡 useEffect のクリーンアップ関数として購読解除を実行
-  return () => {
-    if (unsubscribe) {
-      unsubscribe();
+    if (selectedBoard) {
+      // ボードが変更されたら、まずメッセージをクリア
+      setMessages([]);
+      // 新しいボードのメッセージを取得
+      fetchMessages(selectedBoard);
+      // 💡 購読関数から返されるクリーンアップ関数を変数に保持
+      unsubscribe = subscribeToMessages(selectedBoard);
+    } else {
+      // ボードが選択されていない場合はメッセージをクリア
+      setMessages([]);
     }
-  };
-}, [selectedBoard]);
+
+    // 💡 useEffect のクリーンアップ関数として購読解除を実行
+    return () => {
+      if (unsubscribe) {
+        unsubscribe();
+      }
+    };
+  }, [selectedBoard]);
+
+  // メッセージが更新されたときに自動スクロール
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
 
   const fetchBoards = async () => {
     if (!user) return;
 
     try {
+      console.log('[Chat] ボード取得開始:', { user_id: user.id });
+
       const { data, error } = await supabase
         .from('board_participants')
         .select(`
@@ -80,6 +105,7 @@ useEffect(() => {
             id,
             title,
             purpose,
+            user_id,
             users (
               name,
               photo
@@ -89,7 +115,12 @@ useEffect(() => {
         .eq('user_id', user.id)
         .eq('status', 'accepted');
 
-      if (error) throw error;
+      if (error) {
+        console.error('[Chat] ボード取得エラー:', error);
+        throw error;
+      }
+
+      console.log('[Chat] 取得したボードデータ:', data);
 
       const boards = data?.map(item => ({
         id: item.board.id,
@@ -98,12 +129,14 @@ useEffect(() => {
         users: item.board.users,
       })) || [];
 
+      console.log('[Chat] 処理後のボード数:', boards.length);
+
       setBoards(boards);
       if (boards.length > 0 && !selectedBoard) {
         setSelectedBoard(boards[0].id);
       }
     } catch (error) {
-      console.error('Error fetching boards:', error);
+      console.error('[Chat] Error fetching boards:', error);
     } finally {
       setLoading(false);
     }
@@ -111,6 +144,11 @@ useEffect(() => {
 
   const fetchMessages = async (boardId: string) => {
     try {
+      console.log('[Chat] メッセージ取得開始:', { board_id: boardId });
+      
+      // メッセージをクリア（念のため）
+      setMessages([]);
+      
       const { data, error } = await supabase
         .from('message')
         .select(`
@@ -126,10 +164,20 @@ useEffect(() => {
         .eq('board_id', boardId)
         .order('created_at', { ascending: true });
 
-      if (error) throw error;
+      if (error) {
+        console.error('[Chat] メッセージ取得エラー:', error);
+        throw error;
+      }
+
+      console.log('[Chat] 取得したメッセージ数:', data?.length || 0);
+      
+      // 新しいボードのメッセージを直接設定（マージしない）
       setMessages(data || []);
+
     } catch (error) {
-      console.error('Error fetching messages:', error);
+      console.error('[Chat] Error fetching messages:', error);
+      // エラー時もメッセージをクリア
+      setMessages([]);
     }
   };
 
@@ -155,22 +203,85 @@ useEffect(() => {
 
   const sendMessage = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!user || !selectedBoard || !newMessage.trim()) return;
+    if (!user || !selectedBoard || !newMessage.trim()) {
+      setError('メッセージを入力してください');
+      return;
+    }
 
+    setError(null);
     setSendingMessage(true);
     try {
-      const { error } = await supabase
+      console.log('[Chat] メッセージ送信開始:', {
+        user_id: user.id,
+        board_id: selectedBoard,
+        content: newMessage.trim()
+      });
+
+      // まず、ユーザーがボードの参加者か確認
+      const { data: participant, error: participantError } = await supabase
+        .from('board_participants')
+        .select('id, status')
+        .eq('board_id', selectedBoard)
+        .eq('user_id', user.id)
+        .eq('status', 'accepted')
+        .single();
+
+      if (participantError || !participant) {
+        console.error('[Chat] 参加者チェックエラー:', participantError);
+        throw new Error('このボードの参加者ではありません。メッセージを送信するには、ボードに参加する必要があります。');
+      }
+
+      const messageContent = newMessage.trim();
+      
+      // メッセージを送信し、作成されたメッセージデータを取得
+      const { data: insertedMessage, error: insertError } = await supabase
         .from('message')
         .insert({
           board_id: selectedBoard,
           user_id: user.id,
-          content: newMessage.trim(),
-        });
+          content: messageContent,
+        })
+        .select(`
+          id,
+          content,
+          created_at,
+          user_id,
+          users!inner (
+            name,
+            photo
+          )
+        `)
+        .single();
 
-      if (error) throw error;
+      if (insertError) {
+        console.error('[Chat] メッセージ挿入エラー:', insertError);
+        // RLSポリシーエラーの場合、より分かりやすいメッセージを表示
+        if (insertError.code === '42501' || insertError.message.includes('policy')) {
+          throw new Error('メッセージを送信する権限がありません。SupabaseのRLSポリシーが正しく設定されているか確認してください。');
+        }
+        throw insertError;
+      }
+
+      console.log('[Chat] メッセージ送信成功:', insertedMessage);
+
+      // メッセージを即座にローカルステートに追加
+      if (insertedMessage) {
+        setMessages(prev => {
+          // 重複チェック（念のため）
+          const exists = prev.some(msg => msg.id === insertedMessage.id);
+          if (exists) {
+            return prev;
+          }
+          return [...prev, insertedMessage];
+        });
+      }
+
       setNewMessage('');
-    } catch (error) {
-      console.error('Error sending message:', error);
+      setError(null);
+    } catch (error: any) {
+      console.error('[Chat] メッセージ送信エラー:', error);
+      const errorMessage = error?.message || 'メッセージの送信に失敗しました。もう一度お試しください。';
+      setError(errorMessage);
     } finally {
       setSendingMessage(false);
     }
@@ -220,71 +331,113 @@ useEffect(() => {
         {/* Board List */}
         <div className="border-b border-gray-200">
           <div className="flex space-x-2 p-4 overflow-x-auto">
-            {boards.map((board) => (
-              <button
-                key={board.id}
-                onClick={() => setSelectedBoard(board.id)}
-                className={`
-                  flex-shrink-0 px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200
-                  ${selectedBoard === board.id
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                  }
-                `}
-              >
-                {board.title}
-              </button>
-            ))}
+            {boards.length === 0 ? (
+              <div className="w-full text-center py-4 text-gray-500 text-sm">
+                参加しているボードがありません
+              </div>
+            ) : (
+              boards.map((board) => (
+                <button
+                  key={board.id}
+                  onClick={() => {
+                    // ボードを切り替えるときにメッセージを即座にクリア
+                    if (selectedBoard !== board.id) {
+                      setMessages([]);
+                    }
+                    setSelectedBoard(board.id);
+                  }}
+                  className={`
+                    flex-shrink-0 px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200
+                    ${selectedBoard === board.id
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                    }
+                  `}
+                >
+                  {board.title}
+                </button>
+              ))
+            )}
           </div>
         </div>
 
         {/* Messages */}
-        <div className="h-96 overflow-y-auto p-4 space-y-4">
-          {messages.map((message) => (
-            <div
-              key={message.id}
-              className={`flex ${message.user_id === user?.id ? 'justify-end' : 'justify-start'}`}
-            >
-              <div className={`flex items-start space-x-2 max-w-xs lg:max-w-md ${message.user_id === user?.id ? 'flex-row-reverse space-x-reverse' : ''}`}>
-                <div className="w-8 h-8 bg-gradient-to-r from-green-400 to-blue-500 rounded-full flex items-center justify-center flex-shrink-0">
-                  {message.users.photo ? (
-                    <img 
-                      src={message.users.photo} 
-                      alt="Avatar" 
-                      className="w-full h-full rounded-full object-cover"
-                    />
-                  ) : (
-                    <User className="h-4 w-4 text-white" />
-                  )}
-                </div>
-                <div className={`rounded-lg px-3 py-2 ${message.user_id === user?.id ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-900'}`}>
-                  <p className="text-sm">{message.content}</p>
-                  <p className={`text-xs mt-1 ${message.user_id === user?.id ? 'text-blue-200' : 'text-gray-500'}`}>
-                    {message.created_at ? formatTime(message.created_at) : '不明'}
-                  </p>
-                </div>
-              </div>
+        <div 
+          ref={messagesContainerRef}
+          className="h-96 overflow-y-auto p-4 space-y-4"
+          id="messages-container"
+        >
+          {messages.length === 0 ? (
+            <div className="text-center py-8 text-gray-500 text-sm">
+              メッセージがありません。最初のメッセージを送信しましょう！
             </div>
-          ))}
+          ) : (
+            <>
+              {messages.map((message) => (
+                <div
+                  key={message.id}
+                  className={`flex ${message.user_id === user?.id ? 'justify-end' : 'justify-start'}`}
+                >
+                  <div className={`flex items-start gap-2 max-w-xs lg:max-w-md ${message.user_id === user?.id ? 'flex-row-reverse' : ''}`}>
+                    {/* アバターと名前 */}
+                    <div className="flex flex-col items-center flex-shrink-0">
+                      <div className="w-10 h-10 bg-gradient-to-r from-green-400 to-blue-500 rounded-full flex items-center justify-center">
+                        {message.users.photo ? (
+                          <img 
+                            src={message.users.photo} 
+                            alt={message.users.name || 'Avatar'} 
+                            className="w-full h-full rounded-full object-cover"
+                          />
+                        ) : (
+                          <User className="h-5 w-5 text-white" />
+                        )}
+                      </div>
+                      <p className="text-xs text-gray-600 mt-1 max-w-[60px] truncate">
+                        {message.users.name || 'ユーザー'}
+                      </p>
+                    </div>
+                    {/* メッセージボックス */}
+                    <div className={`rounded-lg px-3 py-2 ${message.user_id === user?.id ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-900'}`}>
+                      <p className="text-sm">{message.content}</p>
+                      <p className={`text-xs mt-1 ${message.user_id === user?.id ? 'text-blue-200' : 'text-gray-500'}`}>
+                        {message.created_at ? formatTime(message.created_at) : '不明'}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+              <div ref={messagesEndRef} />
+            </>
+          )}
         </div>
 
         {/* Message Input */}
-        <form onSubmit={sendMessage} className="border-t border-gray-200 p-4 flex space-x-2">
-          <Input
-            value={newMessage}
-            onChange={(e) => setNewMessage(e.target.value)}
-            placeholder="メッセージを入力..."
-            className="flex-1"
-            disabled={sendingMessage}
-          />
-          <Button
-            type="submit"
-            loading={sendingMessage}
-            disabled={!newMessage.trim()}
-            className="flex-shrink-0"
-          >
-            <Send className="h-4 w-4" />
-          </Button>
+        <form onSubmit={sendMessage} className="border-t border-gray-200 p-4 space-y-2">
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-3">
+              <p className="text-sm text-red-600">{error}</p>
+            </div>
+          )}
+          <div className="flex space-x-2">
+            <Input
+              value={newMessage}
+              onChange={(e) => {
+                setNewMessage(e.target.value);
+                setError(null); // 入力時にエラーをクリア
+              }}
+              placeholder="メッセージを入力..."
+              className="flex-1"
+              disabled={sendingMessage}
+            />
+            <Button
+              type="submit"
+              loading={sendingMessage}
+              disabled={!newMessage.trim() || sendingMessage}
+              className="flex-shrink-0"
+            >
+              <Send className="h-4 w-4" />
+            </Button>
+          </div>
         </form>
       </div>
     </div>

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -295,6 +295,11 @@ export default function ChatScreen({}: ChatScreenProps) {
     });
   };
 
+  // ハート認証の通知メッセージかどうかを判定
+  const isHeartApprovedMessage = (content: string) => {
+    return content.includes('ハートが認証され、グループチャットに追加されました');
+  };
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-96">
@@ -373,39 +378,55 @@ export default function ChatScreen({}: ChatScreenProps) {
             </div>
           ) : (
             <>
-              {messages.map((message) => (
-                <div
-                  key={message.id}
-                  className={`flex ${message.user_id === user?.id ? 'justify-end' : 'justify-start'}`}
-                >
-                  <div className={`flex items-start gap-2 max-w-xs lg:max-w-md ${message.user_id === user?.id ? 'flex-row-reverse' : ''}`}>
-                    {/* アバターと名前 */}
-                    <div className="flex flex-col items-center flex-shrink-0">
-                      <div className="w-10 h-10 bg-gradient-to-r from-green-400 to-blue-500 rounded-full flex items-center justify-center">
-                        {message.users.photo ? (
-                          <img 
-                            src={message.users.photo} 
-                            alt={message.users.name || 'Avatar'} 
-                            className="w-full h-full rounded-full object-cover"
-                          />
-                        ) : (
-                          <User className="h-5 w-5 text-white" />
-                        )}
+              {messages.map((message) => {
+                const isSystemMessage = isHeartApprovedMessage(message.content);
+                
+                // システムメッセージ（ハート認証通知）の場合はグレー表示
+                if (isSystemMessage) {
+                  return (
+                    <div key={message.id} className="flex justify-center my-2">
+                      <div className="bg-gray-200 text-gray-600 rounded-lg px-4 py-2 max-w-md">
+                        <p className="text-sm text-center">{message.content}</p>
                       </div>
-                      <p className="text-xs text-gray-600 mt-1 max-w-[60px] truncate">
-                        {message.users.name || 'ユーザー'}
-                      </p>
                     </div>
-                    {/* メッセージボックス */}
-                    <div className={`rounded-lg px-3 py-2 ${message.user_id === user?.id ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-900'}`}>
-                      <p className="text-sm">{message.content}</p>
-                      <p className={`text-xs mt-1 ${message.user_id === user?.id ? 'text-blue-200' : 'text-gray-500'}`}>
-                        {message.created_at ? formatTime(message.created_at) : '不明'}
-                      </p>
+                  );
+                }
+                
+                // 通常のメッセージ
+                return (
+                  <div
+                    key={message.id}
+                    className={`flex ${message.user_id === user?.id ? 'justify-end' : 'justify-start'}`}
+                  >
+                    <div className={`flex items-start gap-2 max-w-xs lg:max-w-md ${message.user_id === user?.id ? 'flex-row-reverse' : ''}`}>
+                      {/* アバターと名前 */}
+                      <div className="flex flex-col items-center flex-shrink-0">
+                        <div className="w-10 h-10 bg-gradient-to-r from-green-400 to-blue-500 rounded-full flex items-center justify-center">
+                          {message.users.photo ? (
+                            <img 
+                              src={message.users.photo} 
+                              alt={message.users.name || 'Avatar'} 
+                              className="w-full h-full rounded-full object-cover"
+                            />
+                          ) : (
+                            <User className="h-5 w-5 text-white" />
+                          )}
+                        </div>
+                        <p className="text-xs text-gray-600 mt-1 max-w-[60px] truncate">
+                          {message.users.name || 'ユーザー'}
+                        </p>
+                      </div>
+                      {/* メッセージボックス */}
+                      <div className={`rounded-lg px-3 py-2 ${message.user_id === user?.id ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-900'}`}>
+                        <p className="text-sm">{message.content}</p>
+                        <p className={`text-xs mt-1 ${message.user_id === user?.id ? 'text-blue-200' : 'text-gray-500'}`}>
+                          {message.created_at ? formatTime(message.created_at) : '不明'}
+                        </p>
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
               <div ref={messagesEndRef} />
             </>
           )}

--- a/src/components/posts/CreatePostScreen.tsx
+++ b/src/components/posts/CreatePostScreen.tsx
@@ -35,16 +35,35 @@ export default function CreatePostScreen({ onNavigate }: CreatePostScreenProps) 
     setError('');
 
     try {
-      const { error } = await supabase
+      // ボードを作成
+      const { data: boardData, error: boardError } = await supabase
         .from('board')
         .insert({
           user_id: user.id,
           title: formData.title,
           purpose: formData.purpose,
           limit_count: formData.limit_count ? parseInt(formData.limit_count) : 10,
-        });
+        })
+        .select()
+        .single();
 
-      if (error) throw error;
+      if (boardError) throw boardError;
+
+      // ボード作成者を参加者として追加
+      if (boardData) {
+        const { error: participantError } = await supabase
+          .from('board_participants')
+          .insert({
+            user_id: user.id,
+            board_id: boardData.id,
+            status: 'accepted',
+          });
+
+        if (participantError) {
+          console.error('参加者の追加に失敗:', participantError);
+          // エラーでも続行（既に存在する可能性がある）
+        }
+      }
 
       onNavigate('board');
     } catch (err: any) {

--- a/src/components/posts/CreatePostScreen.tsx
+++ b/src/components/posts/CreatePostScreen.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
+import { Plus } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
+import { sendAutoMessage } from '../../lib/autoMessage';
 import { useAuth } from '../../hooks/useAuth';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
 import TextArea from '../ui/TextArea';
-import { Plus } from 'lucide-react';
+import { DEFAULT_BOARD_CREATION_MESSAGE } from '../../constants/messages';
 
 interface CreatePostScreenProps {
   onNavigate: (screen: string) => void;
@@ -62,6 +64,16 @@ export default function CreatePostScreen({ onNavigate }: CreatePostScreenProps) 
         if (participantError) {
           console.error('参加者の追加に失敗:', participantError);
           // エラーでも続行（既に存在する可能性がある）
+        } else {
+          const autoMessageResult = await sendAutoMessage({
+            boardId: boardData.id,
+            userId: user.id,
+            content: DEFAULT_BOARD_CREATION_MESSAGE,
+          });
+
+          if (!autoMessageResult.success) {
+            console.warn('[CreatePost] 自動メッセージ送信に失敗しました', autoMessageResult.error);
+          }
         }
       }
 

--- a/src/components/posts/PostBoardScreen.tsx
+++ b/src/components/posts/PostBoardScreen.tsx
@@ -3,7 +3,7 @@ import { supabase } from '../../lib/supabase';
 import { useAuth } from '../../hooks/useAuth';
 import LoadingSpinner from '../ui/LoadingSpinner';
 import Button from '../ui/Button';
-import { Users, Calendar, User, MessageCircle } from 'lucide-react';
+import { Users, Calendar, User, MessageCircle, Heart, Check, X, Bell } from 'lucide-react';
 
 interface Board {
   id: string;
@@ -17,20 +17,43 @@ interface Board {
   };
 }
 
+interface LikeRequest {
+  id: string;
+  board_id: string;
+  user_id: string;
+  created_at: string;
+  board: {
+    id: string;
+    title: string;
+  };
+  users: {
+    id: string;
+    name: string;
+    photo: string | null;
+    email: string;
+  };
+}
+
 interface PostBoardScreenProps {
   onNavigate: (screen: string) => void;
 }
 
-type BoardListType = 'my_posts' | 'liked_posts'; // 💡 追加: 表示モードを定義
+type BoardListType = 'my_posts' | 'liked_posts' | 'notifications'; // 💡 追加: 通知タブを追加
 
 export default function PostBoardScreen({ onNavigate }: PostBoardScreenProps) {
   const { user } = useAuth();
   const [boards, setBoards] = useState<Board[]>([]);
+  const [likeRequests, setLikeRequests] = useState<LikeRequest[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeList, setActiveList] = useState<BoardListType>('my_posts'); // 💡 追加: 現在の表示モード
+  const [processingRequest, setProcessingRequest] = useState<string | null>(null);
 
   useEffect(() => {
-    fetchBoards(activeList);
+    if (activeList === 'notifications') {
+      fetchLikeRequests();
+    } else {
+      fetchBoards(activeList);
+    }
   }, [user, activeList]); 
 
   // const fetchBoards = async () => {
@@ -99,6 +122,369 @@ export default function PostBoardScreen({ onNavigate }: PostBoardScreenProps) {
       console.error(`Error fetching ${listType} boards:`, error);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const fetchLikeRequests = async () => {
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      // 自分のボードにいいねした人を取得
+      const { data: myBoards } = await supabase
+        .from('board')
+        .select('id')
+        .eq('user_id', user.id);
+
+      if (!myBoards || myBoards.length === 0) {
+        setLikeRequests([]);
+        setLoading(false);
+        return;
+      }
+
+      const boardIds = myBoards.map(b => b.id);
+
+      // 自分のボードにいいねした人を取得（まだ承認されていない人）
+      const { data: likes, error: likesError } = await supabase
+        .from('like')
+        .select(`
+          id,
+          board_id,
+          user_id,
+          created_at,
+          board!inner (
+            id,
+            title
+          ),
+          users!like_user_id_fkey (
+            id,
+            name,
+            photo,
+            email
+          )
+        `)
+        .in('board_id', boardIds);
+
+      if (likesError) throw likesError;
+
+      // 既に承認されている人を除外
+      const { data: participants } = await supabase
+        .from('board_participants')
+        .select('user_id, board_id')
+        .in('board_id', boardIds)
+        .eq('status', 'accepted');
+
+      const acceptedPairs = new Set(
+        participants?.map(p => `${p.user_id}-${p.board_id}`) || []
+      );
+
+      const filteredLikes = (likes || []).filter(like => {
+        const key = `${like.user_id}-${like.board_id}`;
+        return !acceptedPairs.has(key);
+      }) as LikeRequest[];
+
+      setLikeRequests(filteredLikes);
+    } catch (error) {
+      console.error('Error fetching like requests:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleApprove = async (likeRequest: LikeRequest) => {
+    if (!user) return;
+
+    setProcessingRequest(likeRequest.id);
+    try {
+      console.log('[PostBoard] 承認処理開始:', {
+        likeRequestId: likeRequest.id,
+        boardId: likeRequest.board_id,
+        userId: likeRequest.user_id,
+        currentUserId: user.id
+      });
+
+      // まず、ボード作成者（自分）がboard_participantsに存在するか確認
+      const { data: existingOwner, error: checkOwnerError } = await supabase
+        .from('board_participants')
+        .select('id')
+        .eq('board_id', likeRequest.board_id)
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      if (checkOwnerError && checkOwnerError.code !== 'PGRST116') {
+        console.error('[PostBoard] ボード作成者の確認エラー:', checkOwnerError);
+        throw new Error(`ボード作成者の確認に失敗しました: ${checkOwnerError.message}`);
+      }
+
+      // ボード作成者が参加者として登録されていない場合は追加
+      if (!existingOwner) {
+        console.log('[PostBoard] ボード作成者を参加者として追加');
+        const { data: ownerData, error: ownerError } = await supabase
+          .from('board_participants')
+          .insert({
+            user_id: user.id, // ボード作成者
+            board_id: likeRequest.board_id,
+            status: 'accepted',
+          })
+          .select()
+          .single();
+
+        if (ownerError) {
+          console.error('[PostBoard] ボード作成者の追加に失敗:', ownerError);
+          console.error('[PostBoard] エラー詳細:', {
+            code: ownerError.code,
+            message: ownerError.message,
+            details: ownerError.details,
+            hint: ownerError.hint
+          });
+          
+          // 重複エラー（23505）の場合は既に存在するので続行
+          if (ownerError.code !== '23505') {
+            throw new Error(`ボード作成者の追加に失敗しました: ${ownerError.message}`);
+          }
+        } else {
+          console.log('[PostBoard] ボード作成者の追加に成功:', ownerData);
+        }
+      } else {
+        console.log('[PostBoard] ボード作成者は既に参加者として登録済み');
+      }
+
+      // 既に参加者として登録されているか確認
+      const { data: existingParticipant, error: checkParticipantError } = await supabase
+        .from('board_participants')
+        .select('id, status')
+        .eq('board_id', likeRequest.board_id)
+        .eq('user_id', likeRequest.user_id)
+        .maybeSingle();
+
+      if (checkParticipantError && checkParticipantError.code !== 'PGRST116') {
+        console.error('[PostBoard] 参加者の確認エラー:', checkParticipantError);
+        throw new Error(`参加者の確認に失敗しました: ${checkParticipantError.message}`);
+      }
+
+      if (existingParticipant) {
+        console.log('[PostBoard] 既に参加者として登録済み。ステータスを更新');
+        // 既に存在する場合はステータスを更新
+        const { error: updateError } = await supabase
+          .from('board_participants')
+          .update({ status: 'accepted' })
+          .eq('id', existingParticipant.id);
+
+        if (updateError) {
+          console.error('[PostBoard] ステータス更新エラー:', updateError);
+          throw new Error(`ステータスの更新に失敗しました: ${updateError.message}`);
+        }
+      } else {
+        // いいねした人をboard_participantsに追加
+        console.log('[PostBoard] いいねした人を参加者として追加');
+        
+        // デバッグ: ボードの作成者を確認
+        const { data: boardCheck } = await supabase
+          .from('board')
+          .select('id, user_id, title')
+          .eq('id', likeRequest.board_id)
+          .single();
+        
+        console.log('[PostBoard] ボード情報確認:', {
+          boardId: likeRequest.board_id,
+          boardUserId: boardCheck?.user_id,
+          currentUserId: user.id,
+          isCreator: boardCheck?.user_id === user.id
+        });
+
+        if (!boardCheck || boardCheck.user_id !== user.id) {
+          throw new Error('このボードの作成者ではありません。承認権限がありません。');
+        }
+
+        const { data: participantData, error: participantError } = await supabase
+          .from('board_participants')
+          .insert({
+            user_id: likeRequest.user_id,
+            board_id: likeRequest.board_id,
+            status: 'accepted',
+          })
+          .select()
+          .single();
+
+        if (participantError) {
+          console.error('[PostBoard] 参加者の追加に失敗:', participantError);
+          console.error('[PostBoard] エラー詳細:', {
+            code: participantError.code,
+            message: participantError.message,
+            details: participantError.details,
+            hint: participantError.hint
+          });
+          
+          // RLSポリシーエラーの場合、より詳細な情報を提供
+          if (participantError.code === '42501') {
+            console.error('[PostBoard] RLSポリシーエラー - デバッグ情報:', {
+              boardId: likeRequest.board_id,
+              userId: likeRequest.user_id,
+              currentUserId: user.id,
+              boardCreatorId: boardCheck?.user_id,
+              isBoardCreator: boardCheck?.user_id === user.id
+            });
+            throw new Error(
+              `RLSポリシーエラーが発生しました。\n\n` +
+              `解決方法:\n` +
+              `1. Supabaseダッシュボード（https://supabase.com/dashboard）にアクセス\n` +
+              `2. 左側メニューから「SQL Editor」をクリック\n` +
+              `3. 「New query」をクリック\n` +
+              `4. 以下のSQLをコピー＆ペースト:\n\n` +
+              `ALTER TABLE board_participants DISABLE ROW LEVEL SECURITY;\n\n` +
+              `5. 「Run」ボタンをクリック\n\n` +
+              `詳細は「簡単_RLS無効化手順.md」ファイルを参照してください。`
+            );
+          }
+          
+          // 重複エラーの場合は既に追加されているので続行
+          if (participantError.code !== '23505') {
+            throw new Error(`参加者の追加に失敗しました: ${participantError.message}`);
+          }
+        } else {
+          console.log('[PostBoard] 参加者の追加に成功:', participantData);
+        }
+      }
+
+      // ボード作成者の名前を取得
+      let creatorName = 'ユーザー';
+      try {
+        const { data: creatorData } = await supabase
+          .from('users')
+          .select('name, email')
+          .eq('id', user.id)
+          .single();
+        
+        if (creatorData) {
+          creatorName = creatorData.name || creatorData.email?.split('@')[0] || 'ユーザー';
+        }
+      } catch (nameError) {
+        console.error('ユーザー名の取得に失敗:', nameError);
+        // エラーでも続行
+      }
+
+      // いいねした人に承認通知を送信
+      console.log('[PostBoard] 承認通知を送信:', {
+        user_id: likeRequest.user_id,
+        from_user_id: user.id,
+        board_id: likeRequest.board_id,
+        type: 'accepted'
+      });
+
+      const { data: notificationData, error: notificationError } = await supabase
+        .from('notification')
+        .insert({
+          user_id: likeRequest.user_id,
+          from_user_id: user.id,
+          board_id: likeRequest.board_id,
+          type: 'accepted',
+          message: `${creatorName}さんが「${likeRequest.board.title}」への参加を承認しました`,
+        })
+        .select()
+        .single();
+
+      if (notificationError) {
+        console.error('[PostBoard] 通知の送信に失敗しました:', notificationError);
+        console.error('[PostBoard] エラー詳細:', {
+          code: notificationError.code,
+          message: notificationError.message,
+          details: notificationError.details,
+          hint: notificationError.hint
+        });
+        // 通知エラーは非ブロッキング（承認は成功している）
+      } else {
+        console.log('[PostBoard] 承認通知の送信に成功:', notificationData);
+      }
+
+      // リストから削除
+      setLikeRequests(prev => prev.filter(req => req.id !== likeRequest.id));
+      
+      console.log('[PostBoard] 承認処理が正常に完了しました');
+    } catch (error: any) {
+      console.error('[PostBoard] 承認処理エラー:', error);
+      const errorMessage = error?.message || error?.toString() || '不明なエラーが発生しました';
+      console.error('[PostBoard] エラーメッセージ:', errorMessage);
+      
+      // より詳細なエラーメッセージを表示
+      alert(`承認に失敗しました。\n\nエラー: ${errorMessage}\n\n詳細はブラウザのコンソール（F12）を確認してください。`);
+    } finally {
+      setProcessingRequest(null);
+    }
+  };
+
+  const handleReject = async (likeRequest: LikeRequest) => {
+    if (!user) return;
+
+    setProcessingRequest(likeRequest.id);
+    try {
+      // いいねを削除（または非承認としてマーク）
+      const { error: likeError } = await supabase
+        .from('like')
+        .delete()
+        .eq('id', likeRequest.id);
+
+      if (likeError) throw likeError;
+
+      // ボード作成者の名前を取得
+      let creatorName = 'ユーザー';
+      try {
+        const { data: creatorData } = await supabase
+          .from('users')
+          .select('name, email')
+          .eq('id', user.id)
+          .single();
+        
+        if (creatorData) {
+          creatorName = creatorData.name || creatorData.email?.split('@')[0] || 'ユーザー';
+        }
+      } catch (nameError) {
+        console.error('ユーザー名の取得に失敗:', nameError);
+        // エラーでも続行
+      }
+
+      // いいねした人に非承認通知を送信
+      console.log('[PostBoard] 非承認通知を送信:', {
+        user_id: likeRequest.user_id,
+        from_user_id: user.id,
+        board_id: likeRequest.board_id,
+        type: 'rejected'
+      });
+
+      const { data: notificationData, error: notificationError } = await supabase
+        .from('notification')
+        .insert({
+          user_id: likeRequest.user_id,
+          from_user_id: user.id,
+          board_id: likeRequest.board_id,
+          type: 'rejected',
+          message: `${creatorName}さんが「${likeRequest.board.title}」への参加を非承認しました`,
+        })
+        .select()
+        .single();
+
+      if (notificationError) {
+        console.error('[PostBoard] 通知の送信に失敗しました:', notificationError);
+        console.error('[PostBoard] エラー詳細:', {
+          code: notificationError.code,
+          message: notificationError.message,
+          details: notificationError.details,
+          hint: notificationError.hint
+        });
+        // 通知エラーは非ブロッキング
+      } else {
+        console.log('[PostBoard] 非承認通知の送信に成功:', notificationData);
+      }
+
+      // リストから削除
+      setLikeRequests(prev => prev.filter(req => req.id !== likeRequest.id));
+    } catch (error) {
+      console.error('Error rejecting request:', error);
+      alert('非承認に失敗しました。もう一度お試しください。');
+    } finally {
+      setProcessingRequest(null);
     }
   };
 
@@ -188,79 +574,204 @@ export default function PostBoardScreen({ onNavigate }: PostBoardScreenProps) {
         <p className="text-gray-600">参加したいプロジェクトを見つけよう</p>
       </div>
 
-      {/* <div className="space-y-4">
-        {boards.length === 0 ? (
-          <div className="text-center py-12 space-y-4">
-            <div className="w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center mx-auto">
-              <Users className="h-12 w-12 text-gray-400" />
+      {/* タブ切り替え */}
+      <div className="flex space-x-2 border-b border-gray-200">
+        <button
+          onClick={() => setActiveList('my_posts')}
+          className={`flex-1 py-2 text-center font-medium transition-colors ${
+            activeList === 'my_posts'
+              ? 'border-b-2 border-purple-500 text-purple-600'
+              : 'text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          自分の募集
+        </button>
+        <button
+          onClick={() => setActiveList('liked_posts')}
+          className={`flex-1 py-2 text-center font-medium transition-colors ${
+            activeList === 'liked_posts'
+              ? 'border-b-2 border-purple-500 text-purple-600'
+              : 'text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          いいねした募集
+        </button>
+        <button
+          onClick={() => setActiveList('notifications')}
+          className={`flex-1 py-2 text-center font-medium transition-colors relative ${
+            activeList === 'notifications'
+              ? 'border-b-2 border-purple-500 text-purple-600'
+              : 'text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          <Bell className="h-4 w-4 inline mr-1" />
+          通知
+          {likeRequests.length > 0 && (
+            <span className="absolute top-1 right-2 bg-red-500 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center">
+              {likeRequests.length}
+            </span>
+          )}
+        </button>
+      </div>
+
+      {/* 通知タブの表示 */}
+      {activeList === 'notifications' && (
+        <div className="space-y-4">
+          {loading ? (
+            <div className="flex items-center justify-center h-96">
+              <LoadingSpinner size="lg" />
             </div>
-            <div className="space-y-2">
-              <h3 className="text-lg font-medium text-gray-900">ボードがありません</h3>
-              <p className="text-gray-500">新しいボードが作成されるまでお待ちください</p>
+          ) : likeRequests.length === 0 ? (
+            <div className="text-center py-12 space-y-4">
+              <div className="w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center mx-auto">
+                <Bell className="h-12 w-12 text-gray-400" />
+              </div>
+              <div className="space-y-2">
+                <h3 className="text-lg font-medium text-gray-900">通知がありません</h3>
+                <p className="text-gray-500">いいねのリクエストが来たらここに表示されます</p>
+              </div>
             </div>
-          </div>
-        ) : (
-          boards.map((board) => (
-            <div
-              key={board.id}
-              className="bg-white rounded-xl shadow-md p-6 space-y-4 border border-gray-100 hover:shadow-lg transition-all duration-300"
-            >
-              <div className="flex items-start justify-between">
-                <div className="flex items-center space-x-3">
-                  <div className="w-12 h-12 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center">
-                    {board.users.photo ? (
-                      <img 
-                        src={board.users.photo} 
-                        alt="Avatar" 
-                        className="w-full h-full rounded-full object-cover"
-                      />
-                    ) : (
-                      <User className="h-6 w-6 text-white" />
-                    )}
-                  </div>
-                  <div>
-                    <p className="font-medium text-gray-900">
-                      {board.users.name}
-                    </p>
-                    <div className="flex items-center space-x-2 text-sm text-gray-500">
-                      <Calendar className="h-4 w-4" />
-                      <span>{board.created_at ? formatDate(board.created_at) : '不明'}</span>
+          ) : (
+            likeRequests.map((request) => (
+              <div
+                key={request.id}
+                className="bg-white rounded-xl shadow-md p-6 space-y-4 border border-gray-100"
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center space-x-3">
+                    <div className="w-12 h-12 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center">
+                      {request.users.photo ? (
+                        <img
+                          src={request.users.photo}
+                          alt="Avatar"
+                          className="w-full h-full rounded-full object-cover"
+                        />
+                      ) : (
+                        <User className="h-6 w-6 text-white" />
+                      )}
+                    </div>
+                    <div>
+                      <p className="font-medium text-gray-900">{request.users.name}</p>
+                      <p className="text-sm text-gray-500">{request.board.title}にいいねしました</p>
+                      <div className="flex items-center space-x-2 text-xs text-gray-400 mt-1">
+                        <Calendar className="h-3 w-3" />
+                        <span>{request.created_at ? formatDate(request.created_at) : '不明'}</span>
+                      </div>
                     </div>
                   </div>
                 </div>
-                
-                <span className="bg-purple-100 text-purple-800 text-sm px-3 py-1 rounded-full font-medium">
-                  ボード
-                </span>
-              </div>
 
-              <div className="space-y-2">
-                <h3 className="text-xl font-bold text-gray-900">{board.title}</h3>
-                <p className="text-gray-600">{board.purpose}</p>
-              </div>
-
-              <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-4 text-sm text-gray-500">
-                  <div className="flex items-center space-x-1">
-                    <Users className="h-4 w-4" />
-                    <span>
-                      参加者数制限: {board.limit_count || 10}名
-                    </span>
-                  </div>
+                <div className="flex space-x-2">
+                  <Button
+                    onClick={() => handleApprove(request)}
+                    loading={processingRequest === request.id}
+                    disabled={processingRequest !== null}
+                    className="flex-1 bg-green-600 hover:bg-green-700"
+                  >
+                    <Check className="h-4 w-4 mr-1" />
+                    承認
+                  </Button>
+                  <Button
+                    onClick={() => handleReject(request)}
+                    loading={processingRequest === request.id}
+                    disabled={processingRequest !== null}
+                    variant="outline"
+                    className="flex-1 border-red-300 text-red-600 hover:bg-red-50"
+                  >
+                    <X className="h-4 w-4 mr-1" />
+                    非承認
+                  </Button>
                 </div>
+              </div>
+            ))
+          )}
+        </div>
+      )}
 
-                <Button
-                  onClick={() => handleJoinBoard(board.id)}
-                  className="flex items-center space-x-2"
-                >
-                  <MessageCircle className="h-4 w-4" />
-                  <span>参加する</span>
-                </Button>
+      {/* 自分の募集・いいねした募集の表示 */}
+      {(activeList === 'my_posts' || activeList === 'liked_posts') && (
+        <div className="space-y-4">
+          {loading ? (
+            <div className="flex items-center justify-center h-96">
+              <LoadingSpinner size="lg" />
+            </div>
+          ) : boards.length === 0 ? (
+            <div className="text-center py-12 space-y-4">
+              <div className="w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center mx-auto">
+                <Users className="h-12 w-12 text-gray-400" />
+              </div>
+              <div className="space-y-2">
+                <h3 className="text-lg font-medium text-gray-900">
+                  {activeList === 'my_posts' ? '募集がありません' : 'いいねした募集がありません'}
+                </h3>
+                <p className="text-gray-500">
+                  {activeList === 'my_posts'
+                    ? '新しい募集を作成してみましょう'
+                    : 'おすすめ画面で気になるボードを見つけてみましょう'}
+                </p>
               </div>
             </div>
-          ))
-        )}
-      </div> */}
+          ) : (
+            boards.map((board) => (
+              <div
+                key={board.id}
+                className="bg-white rounded-xl shadow-md p-6 space-y-4 border border-gray-100 hover:shadow-lg transition-all duration-300"
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center space-x-3">
+                    <div className="w-12 h-12 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center">
+                      {board.users.photo ? (
+                        <img
+                          src={board.users.photo}
+                          alt="Avatar"
+                          className="w-full h-full rounded-full object-cover"
+                        />
+                      ) : (
+                        <User className="h-6 w-6 text-white" />
+                      )}
+                    </div>
+                    <div>
+                      <p className="font-medium text-gray-900">{board.users.name}</p>
+                      <div className="flex items-center space-x-2 text-sm text-gray-500">
+                        <Calendar className="h-4 w-4" />
+                        <span>{board.created_at ? formatDate(board.created_at) : '不明'}</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <span className="bg-purple-100 text-purple-800 text-sm px-3 py-1 rounded-full font-medium">
+                    {activeList === 'my_posts' ? '自分の募集' : 'いいね済み'}
+                  </span>
+                </div>
+
+                <div className="space-y-2">
+                  <h3 className="text-xl font-bold text-gray-900">{board.title}</h3>
+                  <p className="text-gray-600">{board.purpose}</p>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-4 text-sm text-gray-500">
+                    <div className="flex items-center space-x-1">
+                      <Users className="h-4 w-4" />
+                      <span>参加者数制限: {board.limit_count || 10}名</span>
+                    </div>
+                  </div>
+
+                  {activeList === 'liked_posts' && (
+                    <Button
+                      onClick={() => handleJoinBoard(board.id)}
+                      className="flex items-center space-x-2"
+                    >
+                      <MessageCircle className="h-4 w-4" />
+                      <span>トークへ</span>
+                    </Button>
+                  )}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,3 +1,4 @@
 export const DEFAULT_JOIN_MESSAGE_TEMPLATE = '[USERNAME]が参加しました。';
 export const DEFAULT_BOARD_CREATION_MESSAGE = 'ボードを作成しました！よろしくお願いします。';
+export const HEART_APPROVED_MESSAGE_TEMPLATE = '[USERNAME]さんのハートが認証され、グループチャットに追加されました。';
 

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_JOIN_MESSAGE_TEMPLATE = '[USERNAME]が参加しました。';
+export const DEFAULT_BOARD_CREATION_MESSAGE = 'ボードを作成しました！よろしくお願いします。';
+

--- a/src/lib/autoMessage.ts
+++ b/src/lib/autoMessage.ts
@@ -1,0 +1,77 @@
+import type { PostgrestError } from '@supabase/supabase-js';
+import { supabase } from './supabase';
+
+interface AutoMessageOptions {
+  boardId: string;
+  userId: string;
+  content?: string; // オプショナルに変更（テンプレートを使用する場合）
+  messageTemplate?: string; // メッセージテンプレート（例: "[USERNAME]が参加しました。"）
+}
+
+type AutoMessageResult =
+  | { success: true }
+  | { success: false; error?: PostgrestError | Error };
+
+export async function sendAutoMessage({
+  boardId,
+  userId,
+  content,
+  messageTemplate,
+}: AutoMessageOptions): Promise<AutoMessageResult> {
+  let finalContent: string;
+
+  // メッセージテンプレートが指定されている場合、ユーザー名を取得して置換
+  if (messageTemplate) {
+    try {
+      const { data: userData, error: userError } = await supabase
+        .from('users')
+        .select('name')
+        .eq('id', userId)
+        .single();
+
+      if (userError) {
+        console.error('[AutoMessage] ユーザー名の取得に失敗しました:', userError);
+        // ユーザー名取得に失敗した場合は、デフォルト値を使用
+        const userName = 'ユーザー';
+        finalContent = messageTemplate.replace('[USERNAME]', userName);
+      } else {
+        const userName = userData?.name || 'ユーザー';
+        finalContent = messageTemplate.replace('[USERNAME]', userName);
+      }
+    } catch (error) {
+      console.error('[AutoMessage] ユーザー名取得エラー:', error);
+      finalContent = messageTemplate.replace('[USERNAME]', 'ユーザー');
+    }
+  } else if (content) {
+    finalContent = content.trim();
+  } else {
+    return {
+      success: false,
+      error: new Error('EMPTY_CONTENT'),
+    };
+  }
+
+  if (!finalContent) {
+    return {
+      success: false,
+      error: new Error('EMPTY_CONTENT'),
+    };
+  }
+
+  const { error } = await supabase.from('message').insert({
+    board_id: boardId,
+    user_id: userId,
+    content: finalContent,
+  });
+
+  if (error) {
+    console.error('[AutoMessage] 自動メッセージ送信に失敗しました:', error);
+    return {
+      success: false,
+      error,
+    };
+  }
+
+  return { success: true };
+}
+


### PR DESCRIPTION
<!-- PRのbaseブランチはdevelopでお願いします！ -->

## 概要

<!-- このセクションでは、この PR の目的と概要を簡潔に説明してください。 -->
トーク画面の作成

<!-- このセクションでは、この PR が関連する Issue やタスクをリンクしてください。以下のように記述します。 -->

- 関連 Issue: #9

<!-- このセクションでは、具体的な変更点や修正箇所をスクリーンショットや動画で示してください。 -->

チャットの即時更新
ChatScreen.tsx の送信処理を見直し、送信直後にローカル状態へ反映して自動スクロール。
トーク切り替え時のリセット
別トークへ移動した際に旧トークのメッセージを即クリアし、選択トークだけ表示。
メッセージ表示改善
各メッセージに送信者名をアバター下へ表示して、誰の発信か一目で分かるようにした。
いいね通知 & 承認フロー整備
PostBoardScreen.tsx ほかで通知タブ・リクエスト管理を追加。承認/拒否ボタンから board_participants 更新と通知送信を実施。
ボード作成時の参加者登録
CreatePostScreen.tsx にて作成者自身を board_participants に即登録するよう変更。
通知テーブル追加
notification テーブルと関連 RLS ポリシー用 SQL を用意（開発用に RLS 無効化スクリプトも同梱）。
RLS 対応のサポート資料
ポリシー適用手順や無効化手順を複数の SQL / ドキュメントとして提供。
いいね承認時のエラーハンドリング強化
承認失敗時に詳細ログを出し、RLS まわりの問題点が分かるようにした。
トータルで、いいね → 承認 → 共通トーク部屋で会話、までの流れを完成させるための変更と、UX 改善・Supabase 側の目詰まり解消を行いました。
